### PR TITLE
create and expose getExifFromNodeBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ exiftool.getExifFromLocalFileUsingNodeFs(fs, imgFile, function(exif) {
 });
 ```
 
+Or for node.js if the image is already in a Buffer:
+
+```
+var exiftool = require('exiftool.js');
+
+exiftool.getExifFromNodeBuffer(buffer, function(exif) {
+    console.log("Make is : " + exif["Make"]);
+});
+```
+
 
 Coverage
 ========

--- a/src/README.md
+++ b/src/README.md
@@ -41,6 +41,16 @@ exiftool.getExifFromLocalFileUsingNodeFs(fs, imgFile, function(exif) {
 });
 ```
 
+Or for node.js if the image is already in a Buffer:
+
+```
+var exiftool = require('exiftool.js');
+
+exiftool.getExifFromNodeBuffer(buffer, function(exif) {
+    console.log("Make is : " + exif["Make"]);
+});
+```
+
 
 Coverage
 ========

--- a/src/exiftool.js
+++ b/src/exiftool.js
@@ -1509,7 +1509,10 @@
             }
             str = str + "";
 
-            str = str.replace(/[^a-z0-9 \-\/\.\(\)\:\;\,\©\@\\]/gi, '');
+            // list of what to keep
+            str = str.replace(
+/[^a-z0-9 \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~\©]/gi,
+                '');
             str = str.replace(/^\s+|\s+$/g, ''); // trim
             if (str.toLowerCase() == "undefined"
                     || str.toLowerCase() == "unknown") {

--- a/src/exiftool.js
+++ b/src/exiftool.js
@@ -976,15 +976,17 @@
                 var iActualOffsetHex = (iStringOffset - iTIFFStart)
                         .toString(16);
 
-                if (strTag == 'SerialNumber'
-                        || strTag == 'InternalSerialNumber') { // TODO: needed
-                    // for Fujifilm
-                    // FinePix E900
-                    // but I'm not
-                    // sure why...
-                    iNumValues++;
-                }
-                return oFile.getStringAt(iStringOffset, iNumValues - 1);
+                var ascii = oFile.getStringAt(iStringOffset, iNumValues);
+                // from perl libimage-exiftool Exif.pm
+                // "truncate at null terminator (shouldn't have a null based on
+                // the EXIF spec, but it seems that few people actually read
+                // the spec)
+                // So read the entire string length and trim off the NULL.
+                // trim trailing spaces must be a reference to
+                // "Note: allow spaces instead of nulls in the ID codes because
+                // it is fairly common for camera manufacturers to get this
+                // wrong"
+                return ascii.replace(/\0.*/, "").replace(/ +$/, "")
                 break;
 
             case 3: // short, 16 bit int

--- a/src/exiftool.js
+++ b/src/exiftool.js
@@ -689,17 +689,22 @@
                 }
                 var buffer = new Buffer(100000);
                 fs.read(fd, buffer, 0, 100000, 0, function(err, num) {
-
-                    var binaryResponse = new BinaryFile(buffer
-                            .toString('binary'), 0, 100000);
-
-                    var oEXIF = findEXIFinJPEG(binaryResponse);
-                    if (onComplete)
-                        onComplete((oEXIF || {}), url);
-
+                    getExifFromNodeBuffer(buffer, function(oEXIF) {
+                        if (onComplete)
+                            onComplete(oEXIF, url)
+                        });
                     fs.close(fd);
                 });
             });
+        }
+
+        function getExifFromNodeBuffer(buffer, onComplete) {
+            var binaryResponse = new BinaryFile(buffer
+                    .toString('binary'), 0, Math.min(buffer.length, 100000));
+
+            var oEXIF = findEXIFinJPEG(binaryResponse);
+            if (onComplete)
+                onComplete((oEXIF || {}));
         }
 
         function getExifFromUrl(url, onComplete) {
@@ -1527,6 +1532,7 @@
 
         if (typeof (exports) !== 'undefined') {
             exports.getExifFromLocalFileUsingNodeFs = getExifFromLocalFileUsingNodeFs;
+            exports.getExifFromNodeBuffer = getExifFromNodeBuffer;
         }
 
         if (typeof (jQuery) !== 'undefined') {

--- a/src/exiftool.js
+++ b/src/exiftool.js
@@ -691,7 +691,7 @@
                 fs.read(fd, buffer, 0, 100000, 0, function(err, num) {
 
                     var binaryResponse = new BinaryFile(buffer
-                            .toString('binary'), 0, 1000000);
+                            .toString('binary'), 0, 100000);
 
                     var oEXIF = findEXIFinJPEG(binaryResponse);
                     if (onComplete)


### PR DESCRIPTION
Create and expose getExifFromNodeBuffer for when the image is already in a Node.js Buffer, such as a streamed image that isn't even in a file.


Great utility, I coded up a node.js jpeg comment extractor (I've done that before), for a webcam stream, but then figured out it was Exif not a comment, so I looked around and found this.  In my case I'm streaming the images over http in one multipart request and so I didn't have a file.  Here's a trivial change to modify this module to read an image out of the Node.js Buffer.  

I fixed an issue of creating a Buffer of size 100000, reading the file, then creating a BinaryFile of size 1000000 (10x the size).  Now it won't create a buffer bigger than 100000, or the buffer length.  In my case the images are small, some in the 10KB size, so I didn't want the overhead of creating an image bigger than required.

Thanks for the great work on the module.

Two thoughts.  It would be nice to split up the git repository into the large images and testing data, and the small module source itself, and to move the src/* up to the top level.  That way I could clone the repository into the node_modules directory without it being huge and it working out of the box so to speak, being a clone it would be easier to update or make changes.