### PR TITLE
some infrastructure improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+#### 0.3.3 (2017-10-13)
+
+##### Continuous Integration
+
+* added `generate-changelog` as dev. dependency + related scripts ([a2ffca33](https://github.com/mattburns/exiftool.js/commit/a2ffca336877eea63c0427111f6a2e846895848e))
+
+##### Documentation Changes
+
+* **README:**
+  * added section about `generate-changelog` ([3c91b0c5](https://github.com/mattburns/exiftool.js/commit/3c91b0c59ee495c356ce2b00126bcc803826873f))
+  * added info about ECMAScript 5.1 which is currently used in the project ([e26ac2a4](https://github.com/mattburns/exiftool.js/commit/e26ac2a407e4b2b5d32faab12f4f08c9358a03bf))
+

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ fix(issue #36): duplicate declaration in EXIF.TiffTags 0x0132
 ## How to use from CLI
 ```sh
 # run this to release a new patch version (e.g. 0.3.2 -> 0.3.3)
-yarn release:major
+yarn release:patch
 
 # run this to release a new minor version (e.g. 0.3.2 -> 0.4.0)
-yarn release:major
+yarn release:minor
 
 # run this to release a new major version (e.g. 0.3.2 -> 1.0.0)
 yarn release:major

--- a/README.md
+++ b/README.md
@@ -120,3 +120,37 @@ The script is called `swap_image.pl` but to keep things complicated, I suggest y
 ant
 ```
 
+
+Releases and automated changelog
+================================
+
+We use the [generate-chagelog] tool when releasing new versions.
+This gives us the following goodies:
+- automated CHANGELOG generation
+- automated package version numbering (in `package.json`)
+- new git tag for each release
+
+[generate-chagelog]: https://www.npmjs.com/package/generate-changelog
+
+In order to do that, commit messages that should appear in the changelog should
+follow simple formatting rules `type(optional): message`
+(see the [generate-chagelog] for further info)
+
+Example:
+```
+fix(issue #36): duplicate declaration in EXIF.TiffTags 0x0132
+```
+
+**NOTE:** Make sure, your git remote is named 'origin' because our script expects it.
+
+## How to use from CLI
+```sh
+# run this to release a new patch version (e.g. 0.3.2 -> 0.3.3)
+yarn release:major
+
+# run this to release a new minor version (e.g. 0.3.2 -> 0.4.0)
+yarn release:major
+
+# run this to release a new major version (e.g. 0.3.2 -> 1.0.0)
+yarn release:major
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 exiftool.js
 ===========
 
-A pure javascript implementation of Phil Harvey's excellent [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool/). This extends work started by [Jacob Seidelin](http://www.nihilogic.dk/labs/exifjquery/) and aims to support parsing of all the tags that exiftool is capable of. Currently only jpeg is supported.
+A pure javascript implementation of Phil Harvey's excellent [exiftool].
+This extends work started by [Jacob Seidelin] and aims to support parsing
+of all the tags that exiftool is capable of.
+Currently only jpeg is supported.
 
-See how well we're doing in the latest [Coverage report](http://mattburns.github.io/exiftool.js/test/generated/reports/)
+See how well we're doing in the latest [Coverage report]
 
+The current javascript implementation conforms to the [ECMAScript 5.1]
+which should work in older [node.js] versions.
+
+[exiftool]: http://www.sno.phy.queensu.ca/~phil/exiftool/
+[Coverage report]: http://mattburns.github.io/exiftool.js/test/generated/reports/
+[Jacob Seidelin]: http://www.nihilogic.dk/labs/exifjquery/
+[ECMASCript 5.1]: https://www.ecma-international.org/ecma-262/5.1/
+[node.js]: https://nodejs.org
 
 Usage
 =====

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "exiftool.js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A pure javascript implementation of Phil Harvey's excellent exiftool. This extends work started by Jacob Seidelin and aims to support parsing of all the tags that exiftool is capable of.",
   "main": "exiftool.js",
   "devDependencies": {
-    "mocha": "2.2.1",
-    "generate-changelog": "^1.5.0"
+    "generate-changelog": "^1.5.0",
+    "mocha": "2.2.1"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "A pure javascript implementation of Phil Harvey's excellent exiftool. This extends work started by Jacob Seidelin and aims to support parsing of all the tags that exiftool is capable of.",
   "main": "exiftool.js",
   "devDependencies": {
-    "mocha": "2.2.1"
+    "mocha": "2.2.1",
+    "generate-changelog": "^1.5.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "release:major": "generate-changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && yarn version --new-version major && git push origin && git push origin --tags",
+    "release:minor": "generate-changelog -m && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && yarn version --new-version minor && git push origin && git push origin --tags",
+    "release:patch": "generate-changelog -p && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && yarn version --new-version patch && git push origin && git push origin --tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- added `generate-changelog` to dev. dependencies
- we can now automatically generate new releases including changelog
- added a section about this into README
- also mentioned the JS version explicitly in README ( related to issue #33 )